### PR TITLE
Replace PARALLEL_TESTS argument

### DIFF
--- a/check_coverage.sh
+++ b/check_coverage.sh
@@ -17,7 +17,7 @@ function check_coverage ()
         extend="/opt/ros/$ROS_DISTRO"
 
         local -a opts
-        if [ "$PARALLEL_TESTS" != true ]; then
+        if [ "${PARALLEL_TESTS:=true}" != true ]; then
             opts+=(-j1)
         fi
 

--- a/check_coverage.sh
+++ b/check_coverage.sh
@@ -17,7 +17,7 @@ function check_coverage ()
         extend="/opt/ros/$ROS_DISTRO"
 
         local -a opts
-        if [ "${PARALLEL_TESTS:=true}" != true ]; then
+        if [ $SEQUENTIAL_TESTS == true ]; then
             opts+=(-j1)
         fi
 


### PR DESCRIPTION
Using unset variables can lead to errors. I discovered it when switching from travis to github actions:

https://github.com/PilzDE/pilz_robots/pull/467/commits/4d39936c160dab4b3b229ca187f137f8583d04b2