### PR TITLE
Support python3-coverage for noetic

### DIFF
--- a/check_coverage.sh
+++ b/check_coverage.sh
@@ -5,6 +5,12 @@ function check_coverage ()
 {
     ICI_ADDONS_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+    if [ "$ROS_DISTRO" = "noetic" ]; then
+        PYTHON_COVERAGE_CMD="python3-coverage"
+    else
+        PYTHON_COVERAGE_CMD="python-coverage"
+    fi
+
     source "${ICI_SRC_PATH}/workspace.sh"
     source "${ICI_SRC_PATH}/util.sh"
     source "${ICI_ADDONS_PATH}/${BUILDER}.sh"
@@ -30,14 +36,14 @@ function check_coverage ()
 
             if [ "$line_cov_percentage" != "$required_coverage" ]; then
                 grep -R "^SF.*\|.*,0" $ws/build/$pkg/${pkg}_coverage.info.cleaned | sed -r "s/SF://g" | sed -r "s/DA:/missing line /g" | sed -r "s/,0//g"
-            fi 
+            fi
             echo "---------------------------------------------------"
         else
             cd $HOME/.ros
             echo "Coverage summary for $pkg"
-            python-coverage report --include "$ws/src/$TARGET_REPO_NAME/$pkg/*" --omit "*/$pkg/test/*"
+            $PYTHON_COVERAGE_CMD report --include "$ws/src/$TARGET_REPO_NAME/$pkg/*" --omit "*/$pkg/test/*"
 
-            line_cov_percentage=$(python-coverage report --include "$ws/src/$TARGET_REPO_NAME/$pkg/*" --omit "*/$pkg/test/*" | grep -Poi "TOTAL.* ([0-9]*){2} \K[0-9]*")
+            line_cov_percentage=$($PYTHON_COVERAGE_CMD report --include "$ws/src/$TARGET_REPO_NAME/$pkg/*" --omit "*/$pkg/test/*" | grep -Poi "TOTAL.* ([0-9]*){2} \K[0-9]*")
             required_coverage="100"
         fi
 


### PR DESCRIPTION
## Description

These changes allow the developer to run 'check_coverage.sh' for python coverage on ROS noetic.

Validation: https://github.com/PilzDE/pilz_industrial_motion/commits/imartini/test_python3_coverage

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~~Public api function documentation~~
- [x] ~~Architecture documentation reflects actual code structure~~
- [x] ~~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~~
- [x] ~~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~~
- [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~~CHANGELOG.rst updated~~
- [x] ~~Copyright headers~~
- [x] ~~Examples~~

### Review Checklist
- [x] ~~Soft- and hardware architecture (diagrams and description)~~
- [x] ~~Test review (test plan and individual test cases)~~
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] ~~When is the new feature released?~~
- [x] ~~Which dependent packages do have to be released simultaneously?~~
