### PR TITLE
Cpp coverage with colcon

### DIFF
--- a/check_coverage.sh
+++ b/check_coverage.sh
@@ -22,7 +22,7 @@ function check_coverage ()
     for pkg in "$@"; do
         echo "Creating coverage for [$pkg]"
 
-        ws=~/target_ws
+        ws=$BASEDIR/target_ws
         extend="/opt/ros/$ROS_DISTRO"
 
         run_coverage_build "$extend" "$ws" "$pkg"

--- a/colcon.sh
+++ b/colcon.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
+# Only support cpp coverage. Re-use the build in target workspace.
+# This requires setting CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage"'
 function run_coverage_build ()
 {
     local extend=$1; shift
     local ws=$1; shift
     local pkg=$1
 
-    local -a opts
-    if [ "${PARALLEL_TESTS-true}" != true ]; then
-        opts+=(--executor sequential)
-    fi
+    COVERAGE_EXCLUDES=${COVERAGE_EXCLUDES-""}
 
-    ici_exec_in_workspace "$extend" "$ws" colcon build "${opts[@]}" --cmake-target ${pkg}_coverage \
-        --cmake-target-skip-unavailable --cmake-args -DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
+    cd $ws/build
+    lcov --capture --directory . --initial --output-file $pkg/${pkg}_coverage.base
+    lcov --capture --directory . --output-file $pkg/${pkg}_coverage.info
+    cd $pkg
+    lcov --add-tracefile ${pkg}_coverage.base --add-tracefile ${pkg}_coverage.info --output-file ${pkg}_coverage.total
+    lcov --remove ${pkg}_coverage.total "*/test/*" $COVERAGE_EXCLUDES --output-file ${pkg}_coverage.info.removed
+    lcov --extract ${pkg}_coverage.info.removed "*/src/$pkg/*" --output-file ${pkg}_coverage.info.cleaned
 }


### PR DESCRIPTION
## Description

These changes enable cpp coverage builds based on colcon & lcov (without depending on the code_coverage package).

Python coverage is omitted since we don't make use of it in [psen_scan_v2](https://github.com/PilzDE/psen_scan_v2), yet.

The functionality is demonstrated here: PilzDE/psen_scan_v2/pull/259

